### PR TITLE
bug fix: only allow bp enums to be set on blood potion prefab

### DIFF
--- a/Commands/BloodCommands.cs
+++ b/Commands/BloodCommands.cs
@@ -12,6 +12,10 @@ internal static class BloodCommands
 	[Command("bloodpotion", "bp", description: "Creates a Potion with specified Blood Type, Quality and Value", adminOnly: true)]
 	public static void GiveBloodPotionCommand(ChatCommandContext ctx, BloodType type = BloodType.Frailed, float quality = 100f)
 	{
+		if(!System.Enum.IsDefined(typeof(BloodType), type)){
+			type = BloodType.Frailed;
+		}
+
 		quality = Mathf.Clamp(quality, 0, 100);
 
 		Entity entity = Helper.AddItemToInventory(ctx.Event.SenderCharacterEntity, new PrefabGUID(828432508), 1);


### PR DESCRIPTION
This pull request attempts to fix this issue:  #12 

It's a three line fix that simply adds a check to make sure the int is in the bloodtype enum list. 

Lmk if I need to change anything. cheers 