### PR TITLE
feat: add lvl option to custom spawn command and some default params

### DIFF
--- a/Commands/SpawnNpcCommands.cs
+++ b/Commands/SpawnNpcCommands.cs
@@ -18,12 +18,12 @@ internal static class SpawnCommands
 		{
 			if (Character.Named.TryGetValue(input, out var unit) || Character.Named.TryGetValue("CHAR_" + input, out unit))
 			{
-				return new (Character.NameFromPrefab[unit.GuidHash], unit);
+				return new(Character.NameFromPrefab[unit.GuidHash], unit);
 			}
-// "CHAR_Bandit_Bomber": -1128238456,
+			// "CHAR_Bandit_Bomber": -1128238456,
 			if (int.TryParse(input, out var id) && Character.NameFromPrefab.TryGetValue(id, out var name))
 			{
-				return new (name, new(id));
+				return new(name, new(id));
 			}
 
 			throw ctx.Error($"Can't find unit {input.Bold()}");
@@ -40,7 +40,7 @@ internal static class SpawnCommands
 	}
 
 	[Command("customspawn", "cspn", "customspawn <Prefab Name> [<BloodType> <BloodQuality> <Consumable(\"true/false\")> <Duration>]", "Spawns a modified NPC at your current position.", adminOnly: true)]
-	public static void CustomSpawnNpc(ChatCommandContext ctx, CharacterUnit unit, BloodType type, int quality, bool consumable, int duration = -1)
+	public static void CustomSpawnNpc(ChatCommandContext ctx, CharacterUnit unit, int level = 0, BloodType type = BloodType.Frailed, int quality = 0, bool consumable = true, int duration = -1)
 	{
 		var pos = Core.EntityManager.GetComponentData<LocalToWorld>(ctx.Event.SenderCharacterEntity).Position;
 
@@ -55,6 +55,11 @@ internal static class SpawnCommands
 			blood.UnitBloodType = new PrefabGUID((int)type);
 			blood.BloodQuality = quality;
 			blood.CanBeConsumed = consumable;
+
+			var unitLevel = Core.EntityManager.GetComponentData<UnitLevel>(e);
+			unitLevel.Level = level;
+
+			Core.EntityManager.SetComponentData(e, unitLevel);
 			Core.EntityManager.SetComponentData(e, blood);
 		});
 	}

--- a/Commands/SpawnNpcCommands.cs
+++ b/Commands/SpawnNpcCommands.cs
@@ -39,8 +39,8 @@ internal static class SpawnCommands
 		ctx.Reply($"Spawning {character.Name.Bold()} at your position");
 	}
 
-	[Command("customspawn", "cspn", "customspawn <Prefab Name> [<BloodType> <BloodQuality> <Consumable(\"true/false\")> <Duration>]", "Spawns a modified NPC at your current position.", adminOnly: true)]
-	public static void CustomSpawnNpc(ChatCommandContext ctx, CharacterUnit unit, int level = 0, BloodType type = BloodType.Frailed, int quality = 0, bool consumable = true, int duration = -1)
+	[Command("customspawn", "cspn", "customspawn <Prefab Name> [<BloodType> <BloodQuality> <Consumable(\"true/false\")> <Duration> <level>]", "Spawns a modified NPC at your current position.", adminOnly: true)]
+	public static void CustomSpawnNpc(ChatCommandContext ctx, CharacterUnit unit, BloodType type = BloodType.Frailed, int quality = 0, bool consumable = true, int duration = -1, int level = 0)
 	{
 		var pos = Core.EntityManager.GetComponentData<LocalToWorld>(ctx.Event.SenderCharacterEntity).Position;
 


### PR DESCRIPTION
This pr simply adds a level option for the customspawn command
It also adds some default params to other options for convenience.

There is no check for negative level values values because the game seems to already be doing it. Setting level to anything under 0 creates a unit of level 0